### PR TITLE
Sağ altta 'Bana Sor' chatbot widget'ı ekle

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,5 +13,6 @@
     {{ partial "footer.html" . }}
   </div>
   <script src="{{ "js/theme-toggle.js" | relURL }}" defer></script>
+  {{ partial "cv-chatbot.html" . }}
 </body>
 </html>

--- a/layouts/partials/cv-chatbot.html
+++ b/layouts/partials/cv-chatbot.html
@@ -1,0 +1,27 @@
+<div id="cv-chat-widget">
+  <button id="cv-chat-toggle" class="cv-chat-toggle" type="button" aria-label="Bana soru sor" aria-expanded="false" aria-controls="cv-chat-panel">
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M4 4h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8l-4 4V6a2 2 0 0 1 2-2z"/>
+    </svg>
+  </button>
+
+  <div id="cv-chat-panel" class="cv-chat-panel" hidden>
+    <div class="cv-chat-header">
+      <span>Bana Sor</span>
+      <button id="cv-chat-close" class="cv-chat-close" type="button" aria-label="Kapat">&times;</button>
+    </div>
+    <div id="cv-chat-status" class="cv-chat-status">Başlatılıyor...</div>
+    <div id="cv-chat-messages" class="cv-chat-messages"></div>
+    <div class="cv-chat-chips">
+      <button class="cv-chat-chip" data-q="Hangi üniversitede okuyor?">Eğitimi</button>
+      <button class="cv-chat-chip" data-q="Hangi projelerde çalıştı?">Projeleri</button>
+      <button class="cv-chat-chip" data-q="Yayınladığı makaleler neler?">Yayınları</button>
+      <button class="cv-chat-chip" data-q="Nasıl ulaşabilirim?">İletişim</button>
+    </div>
+    <form id="cv-chat-form" class="cv-chat-input-row">
+      <input id="cv-chat-input" type="text" placeholder="Bir şey sor..." disabled autocomplete="off" />
+      <button type="submit" disabled>Gönder</button>
+    </form>
+  </div>
+</div>
+<script type="module" src="{{ "js/cv-chat-widget.js" | relURL }}"></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,6 +17,7 @@
 <meta name="twitter:image" content="{{ .Site.Params.avatarURL | absURL }}">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/cv-chat-widget.css" | relURL }}">
 {{ if .IsTranslated }}
   {{ range .AllTranslations }}
   <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}">

--- a/static/css/cv-chat-widget.css
+++ b/static/css/cv-chat-widget.css
@@ -1,0 +1,189 @@
+#cv-chat-widget {
+  position: fixed;
+  right: 20px;
+  bottom: 76px;
+  z-index: 9999;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.cv-chat-toggle {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: none;
+  background: var(--link);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  transition: transform 0.15s ease;
+}
+
+.cv-chat-toggle:hover {
+  transform: scale(1.06);
+}
+
+.cv-chat-toggle svg {
+  width: 28px;
+  height: 28px;
+}
+
+.cv-chat-panel {
+  position: fixed;
+  right: 20px;
+  bottom: 148px;
+  width: 340px;
+  max-width: calc(100vw - 32px);
+  max-height: min(480px, calc(100vh - 140px));
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--darker-alt-bg);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.cv-chat-panel[hidden] {
+  display: none;
+}
+
+.cv-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  background: var(--alt-bg);
+  color: var(--alt-fg);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.cv-chat-close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.cv-chat-status {
+  font-size: 12px;
+  color: var(--fg);
+  opacity: 0.7;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--darker-alt-bg);
+}
+
+.cv-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 120px;
+}
+
+.cv-chat-msg {
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 88%;
+  white-space: pre-wrap;
+}
+
+.cv-chat-msg.user {
+  background: var(--link);
+  color: #fff;
+  align-self: flex-end;
+  border-bottom-right-radius: 4px;
+}
+
+.cv-chat-msg.bot {
+  background: var(--alt-bg);
+  color: var(--alt-fg);
+  align-self: flex-start;
+  border-bottom-left-radius: 4px;
+}
+
+.cv-chat-msg.bot a {
+  color: var(--link);
+  text-decoration: underline;
+}
+
+.cv-chat-input-row {
+  display: flex;
+  gap: 6px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--darker-alt-bg);
+}
+
+.cv-chat-input-row input {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--darker-alt-bg);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 13px;
+  min-width: 0;
+}
+
+.cv-chat-input-row button {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: none;
+  background: var(--link);
+  color: #fff;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.cv-chat-input-row input:disabled,
+.cv-chat-input-row button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cv-chat-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 14px 12px;
+}
+
+.cv-chat-chip {
+  background: none;
+  border: 1px solid var(--darker-alt-bg);
+  color: var(--fg);
+  opacity: 0.8;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.cv-chat-chip:hover {
+  opacity: 1;
+  border-color: var(--link);
+}
+
+@media (max-width: 420px) {
+  #cv-chat-widget {
+    right: 16px;
+    bottom: 72px;
+  }
+
+  .cv-chat-panel {
+    right: 16px;
+    bottom: 140px;
+  }
+}

--- a/static/data/cv-kb.json
+++ b/static/data/cv-kb.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "iletisim",
+    "category": "İletişim",
+    "text": "Fatih Emin Karahan, Yapay Zeka Mühendisi (Bilgisayarlı Görü / Doğal Dil İşleme). Telefon: +90 554 692 91 68. E-posta: fatih81443@gmail.com. LinkedIn: linkedin.com/in/fatiheminkarahan. GitHub: github.com/FatihEmin48. Google Scholar: scholar.google.com (Fatih Emin Karahan). Medium: medium.com/@fatiheminkarahan."
+  },
+  {
+    "id": "hakkimda",
+    "category": "Hakkımda",
+    "text": "Fatih Emin Karahan, Bursa Uludağ Üniversitesi'nde Bilgisayar Mühendisliği yüksek lisans öğrencisidir. Yapay zeka alanında, özellikle görüntü işleme, doğal dil işleme ve üretken yapay zeka konularında projeler geliştirmektedir. Akıllı tarım teknolojileri, medikal görüntü analizi ve veri işleme süreçleri üzerine yenilikçi projeler geliştirmiştir."
+  },
+  {
+    "id": "egitim-yuksek-lisans",
+    "category": "Eğitim",
+    "text": "Bursa Uludağ Üniversitesi - Bilgisayar Mühendisliği Yüksek Lisans, 2024-2026. Odak alanları: Bilgisayarlı Görü, Makine Öğrenmesi, Doğal Dil İşleme, Biyoenformatik, Akıllı Tarım Sistemleri."
+  },
+  {
+    "id": "egitim-pedagojik",
+    "category": "Eğitim",
+    "text": "Bursa Uludağ Üniversitesi - Pedagojik Formasyon, 2024-2025. Odak alanları: Eğitime Giriş, Sınıf Yönetimi, Rehberlik, Öğretim İlke ve Yöntemleri, Eğitimde Ölçme Yöntemleri."
+  },
+  {
+    "id": "egitim-lisans",
+    "category": "Eğitim",
+    "text": "Bursa Uludağ Üniversitesi - Bilgisayar Mühendisliği Lisans, 2019-2023. Temel beceriler: Python, Java, SQL, Algoritmalar, Problem Analizi, Proje Yönetimi, Sunum Hazırlama."
+  },
+  {
+    "id": "yetenek-diller",
+    "category": "Teknik Yetenekler",
+    "text": "Programlama Dilleri: Python, Java, Swift, SQL, Arduino IDE."
+  },
+  {
+    "id": "yetenek-cv",
+    "category": "Teknik Yetenekler",
+    "text": "Bilgisayarlı Görü becerileri: OpenCV, YOLO (v5-v11), CreateML, EfficientNet, ResNet."
+  },
+  {
+    "id": "yetenek-nlp",
+    "category": "Teknik Yetenekler",
+    "text": "Doğal Dil İşleme becerileri: Tokenization, Yapay Zeka Ajanları (AI Agents), RAG (Retrieval-Augmented Generation)."
+  },
+  {
+    "id": "yetenek-ml",
+    "category": "Teknik Yetenekler",
+    "text": "Makine Öğrenmesi becerileri: Scikit-Learn, Sınıflandırma ve Regresyon Algoritmaları."
+  },
+  {
+    "id": "yetenek-dl",
+    "category": "Teknik Yetenekler",
+    "text": "Derin Öğrenme becerileri: TensorFlow, PyTorch, NumPy, Matplotlib, Pandas."
+  },
+  {
+    "id": "yetenek-diger",
+    "category": "Teknik Yetenekler",
+    "text": "Diğer araçlar: CVAT, Firebase, Flutter, Git, Linux, Arduino, Raspberry Pi, Jetson Nano."
+  },
+  {
+    "id": "deneyim-searcly",
+    "category": "Mesleki Deneyim",
+    "text": "SEARCLY, Bilgisayarlı Görü - Yapay Zeka Mühendisi, 05.2024-10.2024, Bursa. Web çekme teknikleriyle 500.000+ görüntü veri seti oluşturdu ve 300.000 görüntüyü model eğitimi için hazırladı. ResNet ve EfficientNet modellerini eğitip optimize etti. YOLOv10 nesne tespit modelini özel veri seti üzerinde eğitip üretim ortamına dağıttı."
+  },
+  {
+    "id": "deneyim-gorsentam",
+    "category": "Mesleki Deneyim",
+    "text": "GÖRSENTAM, Bilgisayarlı Görü - Yapay Zeka Mühendisi Stajyeri, 02.2023-05.2023, Bursa. Flutter ile çapraz platform mobil uygulama geliştirdi. YOLOv5 ile gerçek zamanlı görüntü işleme uygulaması tasarladı. CVAT ile görüntü etiketleme sürecini yönetti ve etiketleme ekibinin liderliğini yaptı. Bitirme tezi projesinde şirketle işbirliği yaptı."
+  },
+  {
+    "id": "deneyim-vemus",
+    "category": "Mesleki Deneyim",
+    "text": "VEMUS, Mobil Geliştirici Stajyeri, 10.2022-01.2023, Bursa. Java ve Firebase kullanarak Android mobil uygulaması geliştirdi. Şirketin 'HopinLock' akıllı kilit uygulamasında özellik geliştirme ve hata düzeltme yaptı."
+  },
+  {
+    "id": "proje-fenolojik",
+    "category": "Projeler",
+    "text": "Ürün Türü ve Fenolojik Evre Tanımlanması için Uçtan Uca Bir Derin Öğrenme Çerçevesi (2026). Bamya, biber ve patlıcan bitkilerinin dört gelişim evresini (tohum, tomurcuk, çiçek, hasat edilebilir meyve) tespit eden 12 sınıflı bir derin öğrenme çerçevesi geliştirdi. Muğla'daki tarım alanlarından topladığı görüntüleri açık kaynak verilerle zenginleştirerek yeni bir etiketli veri seti oluşturdu. YOLO, Faster R-CNN ve RT-DETR-L mimarilerini karşılaştırdı; mAP@0.5:0.95 = %72,81 sonucuna ulaştı. Doç. Dr. Gıyasettin Özcan danışmanlığında yürütülen çalışma IEEE Access dergisinde yayımlandı."
+  },
+  {
+    "id": "proje-broiler",
+    "category": "Projeler",
+    "text": "YOLO Tabanlı Derin Öğrenme Modeli ile Broiler Tavuklarda Haftalık Gelişim Aşamalarının ve Kesim Zamanının Otomatik Tespiti (2026). Tavuk çiftliklerinde kesim zamanı gelen tavukları otomatik tespit eden yapay zeka sistemi geliştirdi. Gerçek çiftlik ortamından veri toplama ve model eğitimi süreçlerini yönetti. Çalışma ESTUDAM Bilişim Dergisi'nde yayımlandı."
+  },
+  {
+    "id": "proje-dermatoloji",
+    "category": "Projeler",
+    "text": "Yapay Zeka Destekli Dermatoloji Tanı Sistemi (2025). Deri biyopsisi görüntülerinde dermis, epidermis katmanları ve atipik hücrelerin bölütlenmesi için yapay zeka modeli geliştirdi. Bursa Uludağ Üniversitesi Hastanesi'nden temin edilen tıbbi verilerle veri seti hazırladı, CVAT ile hassas etiketleme yaptı. Doç. Dr. Gıyasettin Özcan ile akademik yayın hazırlığı devam ediyor."
+  },
+  {
+    "id": "proje-teknofest",
+    "category": "Projeler",
+    "text": "TEKNOFEST Otonom Traktör Yarışması (2024). Yabani ot ve marul bitkilerini tespit eden görüntü işleme sistemi geliştirdi. GPS tabanlı hassas konum belirleme ve otonom navigasyon algoritması tasarladı. Tespit edilen bitki sıralarından otomatik şerit oluşturma ve takip sistemi uyguladı. Jetson Nano üzerinde gerçek zamanlı görüntü işleme optimizasyonu yaptı."
+  },
+  {
+    "id": "yayinlar",
+    "category": "Yayınlar",
+    "text": "Yayınlar: 'An End-to-End Deep Learning Framework for Crop Type and Phenological Stage Identification', Karahan, F. E., Celikel, T., & Ozcan, G., IEEE Access, 14, 97546-97558 (2026), doi.org/10.1109/ACCESS.2026.3707086. 'YOLO Tabanlı Derin Öğrenme Modeli ile Broiler Tavuklarda Haftalık Gelişim Aşamalarının ve Kesim Zamanının Otomatik Tespiti', Karahan, F. E., & Özcan, G., ESTUDAM Bilişim Dergisi, 1, 31-36 (2026), doi.org/10.53608/estudambilisim.1907006."
+  },
+  {
+    "id": "referans",
+    "category": "Referans",
+    "text": "Referans: Doç. Dr. Gıyasettin Özcan, Yüksek Lisans Danışmanı, Bursa Uludağ Üniversitesi. E-posta: gozcan@uludag.edu.tr. Telefon: +90 (224) 294 2792."
+  }
+]

--- a/static/js/cv-chat-widget.js
+++ b/static/js/cv-chat-widget.js
@@ -1,0 +1,195 @@
+import { pipeline, cos_sim, env } from "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.17.2";
+
+env.allowLocalModels = false;
+
+const CATEGORY_KEYWORDS = {
+  "İletişim": ["iletişim", "telefon", "e-posta", "eposta", "email", "mail", "linkedin", "github", "ulaş", "scholar", "medium"],
+  "Eğitim": ["eğitim", "okul", "üniversite", "lisans", "yüksek lisans", "mezun", "formasyon", "okuyor", "okudu"],
+  "Teknik Yetenekler": ["beceri", "yetenek", "teknoloji", "araç", "programlama dil", "hangi dil", "kullandığı dil", "hakim"],
+  "Mesleki Deneyim": ["deneyim", "iş yeri", "şirket", "firma", "kariyer", "staj", "işe girdi"],
+  "Projeler": ["proje", "geliştirdiği proje", "hangi projelerde"],
+  "Yayınlar": ["yayın", "makale", "publication", "dergi", "doi", "bilimsel"],
+  "Referans": ["referans", "danışman", "tavsiye mektubu"],
+  "Hakkımda": ["hakkında kim", "kimdir", "kendini tanıt", "biyografi"],
+};
+
+function matchCategories(question) {
+  const q = question.toLocaleLowerCase("tr-TR");
+  return Object.entries(CATEGORY_KEYWORDS)
+    .filter(([, keywords]) => keywords.some((k) => q.includes(k)))
+    .map(([category]) => category);
+}
+
+const LINK_PATTERN =
+  /(https?:\/\/[^\s)]+|(?:www\.)?(?:linkedin\.com|github\.com|scholar\.google\.com|medium\.com|doi\.org)\/[^\s)]+|[\w.+-]+@[\w-]+\.[\w.-]+|\+\d[\d\s]{8,}\d)/g;
+
+function renderMessageContent(el, text) {
+  el.textContent = "";
+  let lastIndex = 0;
+  for (const match of text.matchAll(LINK_PATTERN)) {
+    const offset = match.index;
+    if (offset > lastIndex) {
+      el.appendChild(document.createTextNode(text.slice(lastIndex, offset)));
+    }
+    const raw = match[0];
+    const trimmed = raw.replace(/[.,;:)]+$/, "");
+    const trailing = raw.slice(trimmed.length);
+
+    const a = document.createElement("a");
+    a.textContent = trimmed;
+    a.target = "_blank";
+    a.rel = "noopener";
+    if (/^https?:\/\//.test(trimmed)) {
+      a.href = trimmed;
+    } else if (/^(www\.)?(linkedin\.com|github\.com|scholar\.google\.com|medium\.com|doi\.org)\//.test(trimmed)) {
+      a.href = `https://${trimmed}`;
+    } else if (/^[\w.+-]+@[\w-]+\.[\w.-]+$/.test(trimmed)) {
+      a.href = `mailto:${trimmed}`;
+    } else if (/^\+\d/.test(trimmed)) {
+      a.href = `tel:${trimmed.replace(/\s+/g, "")}`;
+    } else {
+      a.href = `https://${trimmed}`;
+    }
+    el.appendChild(a);
+    if (trailing) el.appendChild(document.createTextNode(trailing));
+    lastIndex = offset + raw.length;
+  }
+  if (lastIndex < text.length) {
+    el.appendChild(document.createTextNode(text.slice(lastIndex)));
+  }
+}
+
+const toggleBtn = document.getElementById("cv-chat-toggle");
+const closeBtn = document.getElementById("cv-chat-close");
+const panel = document.getElementById("cv-chat-panel");
+const statusEl = document.getElementById("cv-chat-status");
+const messagesEl = document.getElementById("cv-chat-messages");
+const formEl = document.getElementById("cv-chat-form");
+const inputEl = document.getElementById("cv-chat-input");
+const submitBtn = formEl.querySelector("button");
+
+let extractor;
+let kb = [];
+let kbEmbeddings = [];
+let initStarted = false;
+
+function setStatus(msg) {
+  statusEl.textContent = msg;
+}
+
+function addMessage(role, text) {
+  const div = document.createElement("div");
+  div.className = `cv-chat-msg ${role}`;
+  if (role === "bot") {
+    renderMessageContent(div, text);
+  } else {
+    div.textContent = text;
+  }
+  messagesEl.appendChild(div);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+  return div;
+}
+
+async function embed(text) {
+  const output = await extractor(text, { pooling: "mean", normalize: true });
+  return Array.from(output.data);
+}
+
+async function init() {
+  if (initStarted) return;
+  initStarted = true;
+  try {
+    setStatus("CV bilgi tabanı yükleniyor...");
+    const res = await fetch("/data/cv-kb.json");
+    kb = await res.json();
+
+    setStatus("Yapay zeka modeli tarayıcınıza indiriliyor (ilk seferde ~25MB, sonrasında önbellekten anında yüklenir)...");
+    extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
+
+    setStatus("CV içeriği analiz ediliyor...");
+    kbEmbeddings = [];
+    for (const item of kb) {
+      kbEmbeddings.push(await embed(`${item.category}. ${item.text}`));
+    }
+
+    setStatus("Hazır. Benimle ilgili bir soru sorabilirsin.");
+    inputEl.disabled = false;
+    submitBtn.disabled = false;
+    inputEl.focus();
+  } catch (err) {
+    console.error(err);
+    setStatus("Model yüklenirken bir sorun oluştu. Sayfayı yenilemeyi deneyin.");
+  }
+}
+
+async function answer(question) {
+  const matchedCats = matchCategories(question);
+
+  if (matchedCats.length === 0) {
+    return "Bu konuyla ilgili CV'de bir bilgi bulamadım. Eğitim, iş deneyimi, projeler, teknik beceriler, yayınlar veya iletişim hakkında soru sorabilirsin.";
+  }
+
+  const qVec = await embed(question);
+  const pool = kb.map((item, i) => ({ item, i })).filter(({ item }) => matchedCats.includes(item.category));
+
+  const scored = pool.map(({ item, i }) => ({
+    item,
+    score: cos_sim(qVec, kbEmbeddings[i]),
+  }));
+  scored.sort((a, b) => b.score - a.score);
+
+  const top = scored.slice(0, Math.min(scored.length, 4));
+
+  const groups = new Map();
+  for (const s of top) {
+    if (!groups.has(s.item.category)) groups.set(s.item.category, []);
+    groups.get(s.item.category).push(s.item.text);
+  }
+
+  return [...groups.entries()]
+    .map(([category, texts]) => `${category.toUpperCase()}\n${texts.map((t) => `• ${t}`).join("\n\n")}`)
+    .join("\n\n");
+}
+
+async function handleQuestion(question) {
+  addMessage("user", question);
+  const pending = addMessage("bot", "Düşünüyorum...");
+  try {
+    const reply = await answer(question);
+    renderMessageContent(pending, reply);
+  } catch (err) {
+    console.error(err);
+    renderMessageContent(pending, "Bir hata oluştu, tekrar dener misin?");
+  }
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+formEl.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const question = inputEl.value.trim();
+  if (!question) return;
+  inputEl.value = "";
+  handleQuestion(question);
+});
+
+document.querySelectorAll("#cv-chat-panel .cv-chat-chip").forEach((chip) => {
+  chip.addEventListener("click", () => {
+    if (inputEl.disabled) return;
+    handleQuestion(chip.dataset.q);
+  });
+});
+
+toggleBtn.addEventListener("click", () => {
+  const isOpen = panel.classList.toggle("open");
+  toggleBtn.setAttribute("aria-expanded", String(isOpen));
+  panel.hidden = !isOpen;
+  if (isOpen) {
+    init();
+  }
+});
+
+closeBtn.addEventListener("click", () => {
+  panel.classList.remove("open");
+  panel.hidden = true;
+  toggleBtn.setAttribute("aria-expanded", "false");
+});


### PR DESCRIPTION
## Özet
- Sitenin her sayfasına sağ altta yuvarlak bir chat butonu ekler
- Tıklanınca CV içeriğini (eğitim, deneyim, projeler, yayınlar, iletişim) tarayıcıda çalışan bir yapay zeka ile sorgulayan bir panel açılır
- Tamamen client-side: sunucu, API key veya ek maliyet yok — https://github.com/FatihEmin48/fatih-cv-asistani projesinin aynısı, bu siteye widget olarak entegre edilmiş hali
- Mevcut karanlık/aydınlık tema butonuyla çakışmaması için üstüne, aynı köşede konumlandırıldı

## Test planı
- [x] Hugo build hatasız tamamlanıyor
- [x] Widget butonu her sayfada görünüyor, tema butonuyla çakışmıyor
- [x] Panel açılıp kapanıyor, soru sorulunca CV'den doğru bölüm geliyor
- [x] Karanlık/aydınlık modda görünüm kontrol edildi