### PR TITLE
Mobilde chat butonunu küçült

### DIFF
--- a/static/css/cv-chat-widget.css
+++ b/static/css/cv-chat-widget.css
@@ -178,12 +178,22 @@
 
 @media (max-width: 420px) {
   #cv-chat-widget {
-    right: 16px;
-    bottom: 72px;
+    right: 14px;
+    bottom: 70px;
+  }
+
+  .cv-chat-toggle {
+    width: 46px;
+    height: 46px;
+  }
+
+  .cv-chat-toggle svg {
+    width: 20px;
+    height: 20px;
   }
 
   .cv-chat-panel {
-    right: 16px;
-    bottom: 140px;
+    right: 14px;
+    bottom: 126px;
   }
 }


### PR DESCRIPTION
## Özet
- 420px altındaki ekranlarda chat butonu 60px yerine 46px
- Tema değiştirme butonuna göre konumu sıkılaştırıldı (6px boşluk)
- Panel konumu buna göre güncellendi

## Not
iPhone SE gibi kısa ekranlarda buton, hero başlığındaki "Language" kelimesinin son harfiyle çok hafif (~1-2px) örtüşmeye devam ediyor — mevcut tema butonu sabit konumda olduğu için bizim butonun daha fazla aşağı inecek yeri yok. İstenirse butonu sol alta taşıyarak bu tamamen ortadan kaldırılabilir.

## Test planı
- [x] Hugo build hatasız
- [x] iPhone SE (375x667) görünümünde buton küçüldü, tema butonuyla çakışma yok
- [x] Panel açılıp kapanıyor, tema butonu hâlâ tıklanabilir