### PR TITLE
Tarayıcıda nesne tanıma projesini siteye ekle

### DIFF
--- a/content/browser-object-detector.md
+++ b/content/browser-object-detector.md
@@ -1,0 +1,10 @@
+---
+title: Browser-Based Object Detection
+---
+A real-time object detection tool that runs entirely in the browser. A YOLOv8n model is exported to ONNX and executed client-side with ONNX Runtime Web, so images never leave the device — no server involved.
+
+<!--more-->
+
+Technologies: Python, PyTorch, Ultralytics YOLOv8, ONNX, ONNX Runtime Web, JavaScript
+
+[Try it live](https://fatihemin48.github.io/browser-object-detector/) · [Source code](https://github.com/FatihEmin48/browser-object-detector)

--- a/content/browser-object-detector.tr.md
+++ b/content/browser-object-detector.tr.md
@@ -1,0 +1,10 @@
+---
+title: Tarayıcıda Nesne Tanıma
+---
+Tamamen tarayıcıda çalışan, sunucu gerektirmeyen bir gerçek zamanlı nesne tespiti aracı. YOLOv8n modeli ONNX formatına aktarılıp ONNX Runtime Web ile istemci tarafında çalıştırılıyor; görüntüler cihazdan hiç çıkmıyor.
+
+<!--more-->
+
+Araçlar: Python, PyTorch, Ultralytics YOLOv8, ONNX, ONNX Runtime Web, JavaScript
+
+[Canlı deneyin](https://fatihemin48.github.io/browser-object-detector/) · [Kaynak kod](https://github.com/FatihEmin48/browser-object-detector)

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -40,7 +40,7 @@
   <section class="featured-projects">
     <h2 class="section-heading">{{ i18n "featuredProjectsHeading" }}</h2>
     <div class="project-grid">
-      {{ $slugs := slice "/crop-phenology-detection" "/broiler-chicken-detection" "/ai-dermatology-diagnosis" "/teknofest-autonomous-tractor" }}
+      {{ $slugs := slice "/browser-object-detector" "/crop-phenology-detection" "/broiler-chicken-detection" "/ai-dermatology-diagnosis" "/teknofest-autonomous-tractor" }}
       {{ range $slugs }}
         {{ with $.Site.GetPage . }}
         <article class="project-card">

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -5,7 +5,7 @@
   <section class="project-section">
     <h2 class="section-heading">{{ i18n "researchProjectsHeading" }}</h2>
     <div class="project-grid">
-      {{ range slice "/crop-phenology-detection" "/broiler-chicken-detection" "/ai-dermatology-diagnosis" "/teknofest-autonomous-tractor" }}
+      {{ range slice "/browser-object-detector" "/crop-phenology-detection" "/broiler-chicken-detection" "/ai-dermatology-diagnosis" "/teknofest-autonomous-tractor" }}
         {{ with $.Site.GetPage . }}
         <article class="project-card">
           <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>


### PR DESCRIPTION
## Özet
- Yeni proje sayfası eklendi: `content/browser-object-detector.md` (EN) ve `.tr.md` (TR)
- Ana sayfadaki "Featured Projects" ve Projeler sayfasındaki "Research Projects" listelerine eklendi (en başa, en yeni/interaktif proje olduğu için)
- Sayfa, canlı demoya (fatihemin48.github.io/browser-object-detector) ve kaynak koda bağlantı veriyor

## Test planı
- [x] Hugo build hatasız
- [x] Ana sayfada kart doğru görünüyor (EN)
- [x] Projeler sayfasında hem EN hem TR kart doğru görünüyor
- [x] Proje detay sayfası her iki dilde de doğru başlık/metin/bağlantılarla açılıyor