### PR TITLE
Etiketleme aracını Projeler sayfasına ekle

### DIFF
--- a/content/browser-annotator.md
+++ b/content/browser-annotator.md
@@ -1,0 +1,10 @@
+---
+title: Browser-Based Image Annotation Tool
+---
+A lightweight image annotation tool for building object detection datasets, running entirely in the browser. Draw, move, and resize bounding boxes, manage custom classes, and export directly to YOLO or COCO format.
+
+<!--more-->
+
+Technologies: JavaScript, Canvas API, IndexedDB, JSZip
+
+[Try it live](https://fatihemin48.github.io/browser-annotator/) · [Source code](https://github.com/FatihEmin48/browser-annotator)

--- a/content/browser-annotator.tr.md
+++ b/content/browser-annotator.tr.md
@@ -1,0 +1,10 @@
+---
+title: Tarayıcıda Görüntü Etiketleme Aracı
+---
+Nesne tespiti veri setleri hazırlamak için tamamen tarayıcıda çalışan hafif bir etiketleme aracı. Kutu çizme, taşıma, yeniden boyutlandırma, özel sınıf tanımlama ve doğrudan YOLO ya da COCO formatında dışa aktarma imkânı sunar.
+
+<!--more-->
+
+Araçlar: JavaScript, Canvas API, IndexedDB, JSZip
+
+[Canlı deneyin](https://fatihemin48.github.io/browser-annotator/) · [Kaynak kod](https://github.com/FatihEmin48/browser-annotator)

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -31,6 +31,9 @@ other = "Publications"
 [researchProjectsHeading]
 other = "Research Projects"
 
+[toolsHeading]
+other = "Tools"
+
 [legacyProjectsHeading]
 other = "Earlier Projects"
 

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -31,6 +31,9 @@ other = "Yayınlar"
 [researchProjectsHeading]
 other = "Araştırma Projeleri"
 
+[toolsHeading]
+other = "Araçlar"
+
 [legacyProjectsHeading]
 other = "Eski Projeler"
 

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -17,6 +17,21 @@
     </div>
   </section>
 
+  <section class="project-section">
+    <h2 class="section-heading">{{ i18n "toolsHeading" }}</h2>
+    <div class="project-grid">
+      {{ range slice "/browser-annotator" }}
+        {{ with $.Site.GetPage . }}
+        <article class="project-card">
+          <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+          {{ .Summary }}
+          <a class="read-more" href="{{ .RelPermalink }}">{{ i18n "readMore" }} &rarr;</a>
+        </article>
+        {{ end }}
+      {{ end }}
+    </div>
+  </section>
+
   {{ $enSite := .Site }}
   {{ range hugo.Sites }}{{ if eq .Language.Lang "en" }}{{ $enSite = . }}{{ end }}{{ end }}
   <section class="project-section">


### PR DESCRIPTION
## Özet
- `content/browser-annotator.md` ve `.tr.md` eklendi
- Projeler sayfasında yeni bir "Araçlar" / "Tools" bölümü açıldı, Araştırma Projeleri (yayınlı işler) ile Eski Projeler arasına yerleştirildi
- Böylece yayınlı araştırma projeleri en üstte kalıyor, etiketleme aracı ayrı ve altta, kendi başlığıyla görünüyor

## Test planı
- [x] Hugo build hatasız
- [x] EN ve TR projeler sayfasında sıralama doğru: Research Projects → Tools → Earlier Projects
- [x] Proje detay sayfası her iki dilde doğru açılıyor, canlı demo ve kaynak koda linkli