### PR TITLE
Yayınlar bölümünü ana sayfa ve Projeler sayfasına ekle

### DIFF
--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -53,4 +53,19 @@
     </div>
     <p class="view-all"><a href="{{ "projects/" | relLangURL }}">{{ i18n "viewProjects" }} &rarr;</a></p>
   </section>
+
+  {{ with .Site.GetPage "/about" }}
+  {{ with .Params.publications }}
+  <section class="cv-section publications">
+    <h2 class="section-heading">{{ i18n "publicationsHeading" }}</h2>
+    {{ range . }}
+    <div class="pub-item">
+      <p class="pub-title">{{ .title }}</p>
+      <p class="pub-meta">{{ .authors }} — {{ .venue }} — {{ .year }} —
+        <a href="{{ .url }}" target="_blank" rel="noopener">{{ .url }}</a></p>
+    </div>
+    {{ end }}
+  </section>
+  {{ end }}
+  {{ end }}
 </div>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -2,6 +2,21 @@
 <article class="page">
   <h1>{{ .Title }}</h1>
 
+  {{ with .Site.GetPage "/about" }}
+  {{ with .Params.publications }}
+  <section class="cv-section publications">
+    <h2 class="section-heading">{{ i18n "publicationsHeading" }}</h2>
+    {{ range . }}
+    <div class="pub-item">
+      <p class="pub-title">{{ .title }}</p>
+      <p class="pub-meta">{{ .authors }} — {{ .venue }} — {{ .year }} —
+        <a href="{{ .url }}" target="_blank" rel="noopener">{{ .url }}</a></p>
+    </div>
+    {{ end }}
+  </section>
+  {{ end }}
+  {{ end }}
+
   <section class="project-section">
     <h2 class="section-heading">{{ i18n "researchProjectsHeading" }}</h2>
     <div class="project-grid">


### PR DESCRIPTION
## Summary
- Ana sayfanın en altına "Publications / Yayınlar" bölümü eklendi (About sayfasındaki mevcut publications verisi kullanılıyor)
- Projeler sayfasının en üstüne aynı Yayınlar bölümü eklendi
- Hem İngilizce hem Türkçe sürümlerde çalışıyor (mevcut i18n anahtarları kullanıldı)

## Test plan
- [x] `hugo` build başarıyla tamamlandı
- [x] Üretilen `public/index.html` ve `public/projects/index.html` (ve `tr/` karşılıkları) içinde Yayınlar bölümü doğru konumda ve doğru veriyle render edildiği kontrol edildi