### PR TITLE
Projeler sayfasına Oyunlar bölümü ekle: Hayatta Kalma

### DIFF
--- a/content/hayatta-kalma.md
+++ b/content/hayatta-kalma.md
@@ -1,0 +1,10 @@
+---
+title: Hayatta Kalma
+---
+A top-down horde-survival browser game in the Vampire Survivors style. Auto-attacking weapons fight off waves of enemies while you collect XP, level up, and try to survive as long as possible.
+
+<!--more-->
+
+Technologies: JavaScript, HTML5 Canvas
+
+[Try it live](https://fatihemin48.github.io/hayatta-kalma/) · [Source code](https://github.com/FatihEmin48/hayatta-kalma)

--- a/content/hayatta-kalma.tr.md
+++ b/content/hayatta-kalma.tr.md
@@ -1,0 +1,10 @@
+---
+title: Hayatta Kalma
+---
+Vampire Survivors tarzında, üstten görünümlü bir horde-survival tarayıcı oyunu. Otomatik saldıran silahlarla dalga dalga gelen düşmanlara karşı deneyim toplayıp seviye atlayarak mümkün olduğunca uzun süre hayatta kalmaya çalışıyorsun.
+
+<!--more-->
+
+Araçlar: JavaScript, HTML5 Canvas
+
+[Canlı oyna](https://fatihemin48.github.io/hayatta-kalma/) · [Kaynak kod](https://github.com/FatihEmin48/hayatta-kalma)

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -37,6 +37,9 @@ other = "Tools"
 [legacyProjectsHeading]
 other = "Earlier Projects"
 
+[gamesHeading]
+other = "Games"
+
 [sendEmail]
 other = "Send Email"
 

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -37,6 +37,9 @@ other = "Araçlar"
 [legacyProjectsHeading]
 other = "Eski Projeler"
 
+[gamesHeading]
+other = "Oyunlar"
+
 [sendEmail]
 other = "E-posta Gönder"
 

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -47,6 +47,21 @@
     </div>
   </section>
 
+  <section class="project-section">
+    <h2 class="section-heading">{{ i18n "gamesHeading" }}</h2>
+    <div class="project-grid">
+      {{ range slice "/hayatta-kalma" }}
+        {{ with $.Site.GetPage . }}
+        <article class="project-card">
+          <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+          {{ .Summary }}
+          <a class="read-more" href="{{ .RelPermalink }}">{{ i18n "readMore" }} &rarr;</a>
+        </article>
+        {{ end }}
+      {{ end }}
+    </div>
+  </section>
+
   {{ $enSite := .Site }}
   {{ range hugo.Sites }}{{ if eq .Language.Lang "en" }}{{ $enSite = . }}{{ end }}{{ end }}
   <section class="project-section">


### PR DESCRIPTION
## Özet
- Projeler sayfasına yeni bir "Oyunlar" / "Games" bölümü eklendi (Araştırma Projeleri ve Araçlar bölümlerinin arasına, Eski Projeler'den önce).
- `hayatta-kalma` oyunu (https://github.com/FatihEmin48/hayatta-kalma) bu bölüme eklendi, canlı demo: https://fatihemin48.github.io/hayatta-kalma/
- `hayatta-kalma` reposu public yapıldı ve GitHub Pages üzerinden yayınlandı (egg-detector/browser-annotator ile aynı desen).

## Test planı
- [x] Hugo ile lokal build alındı, hata yok (sadece ilgisiz bir taxonomy uyarısı).
- [x] Hem `/projects` hem `/tr/projects` sayfalarında yeni bölüm ve kart doğru render oluyor (kontrol edildi).
- [x] Canlı demo linki (https://fatihemin48.github.io/hayatta-kalma/) HTTP 200 dönüyor.
- [ ] Merge sonrası canlı sitede (fatiheminkarahan.com) görsel kontrol